### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Grunt wrapper task for [Premailer](https://github.com/alexdunae/premailer/)
 
 
-##Requirements
+## Requirements
 
 This plugin is a [Grunt](http://gruntjs.com/)  wrapper around the [Premailer](https://github.com/alexdunae/premailer/) Ruby gem developed by Alex Dunae. In order to run it you will need the following packages installed on your system:
 
@@ -169,7 +169,7 @@ grunt.initConfig({
 })
 ```
 
-####Usage Notes
+#### Usage Notes
 
 **`BaseUrl` option and stylesheets parsing**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
